### PR TITLE
在线功能问题修复

### DIFF
--- a/api/src/main/java/club/yunzhi/log/controller/UserController.java
+++ b/api/src/main/java/club/yunzhi/log/controller/UserController.java
@@ -118,6 +118,7 @@ public class UserController {
     return userService.resetPassword(id);
   }
 
+
   public class LoginJsonView {
   }
 


### PR DESCRIPTION
经过测试问题有两个
1: 智慧社区2分钟发送一次空日志，但是会偶然有一次日志系统没有接收到空日志的post信息
解决：由1分钟检测一次改为5分钟检测一次
2: 如代码，可能在循环的过程中 最后交互时间 已更改,故在保存前获取最新的交互时间