### PR TITLE
添加锁，修改提醒样式，添加连接数据库的时区

### DIFF
--- a/api/src/main/java/club/yunzhi/log/Schedule/PushDayLogSchedule.java
+++ b/api/src/main/java/club/yunzhi/log/Schedule/PushDayLogSchedule.java
@@ -33,7 +33,6 @@ public class PushDayLogSchedule {
   Long ErrorCount;
   Long WARNCount;
   Timestamp LastSendTime;
-  List messages = new ArrayList<String>();
   String message;
   String ClientName;
   String ClientState;
@@ -62,12 +61,18 @@ public class PushDayLogSchedule {
         this.INFOCount = dayLog.getInfoCount();
         this.ErrorCount = dayLog.getErrorCount();
         this.WARNCount = dayLog.getWarnCount();
-        this.message = "客户端: " + this.ClientName + "\n"
-            + "客户端状态:  " + this.ClientState + "\n"
-            + "最后交互时间:  " + this.LastSendTime + "\n"
-            + "昨日INFO数:   " + this.INFOCount + "\n"
-            + "昨日WARN数:   " + this.WARNCount + "\n"
-            + "昨日ERROR数:  " + this.ErrorCount + "\n";
+        if (this.ClientState == "在线") {
+          this.message = "客户端: " + this.ClientName + "  " + this.ClientState  +  "\uD83D\uDCF6" + "\n"
+                  + "昨日INFO数:   " + this.INFOCount + "\n"
+                  + "昨日WARN数:   " + this.WARNCount + "\n"
+                  + "昨日ERROR数:  " + this.ErrorCount + "\n";
+        } else  {
+          this.message = "客户端: " + this.ClientName + "  " + this.ClientState + "❗" + "\n"
+                  + "最后交互时间:  " + this.LastSendTime + "\n"
+                  + "昨日INFO数:   " + this.INFOCount + "\n"
+                  + "昨日WARN数:   " + this.WARNCount + "\n"
+                  + "昨日ERROR数:  " + this.ErrorCount + "\n";
+        }
         StringBuffer resultBuffer = new StringBuffer();
         String result = message;
         resultBuffer.append(result);
@@ -76,7 +81,7 @@ public class PushDayLogSchedule {
         Date currentTime = new Date();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         String dateString = formatter.format(currentTime);
-        dingService.dingRequest(ding, "执行定时推送任务" + "\n" + dateString + "\n" + messageOfLog);
+        dingService.dingRequest(ding, messageOfLog);
         System.out.println("执行定时推送任务" + dateString + messageOfLog);
       }
     }

--- a/api/src/main/java/club/yunzhi/log/aspect/ClientAuthAspect.java
+++ b/api/src/main/java/club/yunzhi/log/aspect/ClientAuthAspect.java
@@ -32,8 +32,6 @@ public class ClientAuthAspect {
   HttpServletRequest httpServletRequest;
   private final ClientRepository clientRepository;
 
-
-
   private final DingService dingService;
 
   @Autowired
@@ -62,23 +60,9 @@ public class ClientAuthAspect {
     }
     logs.forEach(log -> log.setClient(client));
 
-    logger.debug("设置客户端的状态为在线");
+    logger.debug("如果不在线，设置客户端的状态为在线");
     if (!client.getState()) {
-      client.setState(true);
-      List<Ding> dings = this.dingService.getAllStartDing();
-
-      logger.debug("执行推送任务");
-      for (Ding ding : dings) {
-        if (ding.getClient().getId().equals(client.getId())) {
-          Date currentTime1 = new Date();
-          SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-          String dateString = formatter.format(currentTime1);
-          dingService.dingRequest(ding, "执行推送任务" + "\n" + dateString + "\n"
-                  + ding.getName() + "机器人提示: 客户端" + client.getName() + "已上线");
-        }
-      }
-      client.setRemind(false);
-      clientRepository.save(client);
+       dingService.pushOnlineMessage(client);
     }
     joinPoint.proceed();
   }

--- a/api/src/main/java/club/yunzhi/log/repository/ClientRepository.java
+++ b/api/src/main/java/club/yunzhi/log/repository/ClientRepository.java
@@ -2,8 +2,12 @@ package club.yunzhi.log.repository;
 
 import club.yunzhi.log.entity.Client;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
+import javax.persistence.LockModeType;
+import javax.transaction.Transactional;
 import java.util.Optional;
 
 /**
@@ -11,4 +15,14 @@ import java.util.Optional;
  */
 public interface ClientRepository extends PagingAndSortingRepository<Client, Long>, JpaSpecificationExecutor {
     Client findByToken(String token);
+
+    /**
+     * 查询时加上悲观锁
+     * 在我们没有将其提交事务之前，其他线程是不能获取修改的，需要等待
+     * @param id clientId
+     * @return
+     */
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Client a where a.id = :id")
+    Optional<Client> findClientByIdWithPessimisticLock(Long id);
 }

--- a/api/src/main/java/club/yunzhi/log/service/DingService.java
+++ b/api/src/main/java/club/yunzhi/log/service/DingService.java
@@ -1,5 +1,6 @@
 package club.yunzhi.log.service;
 
+import club.yunzhi.log.entity.Client;
 import club.yunzhi.log.entity.Ding;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,4 +37,16 @@ public interface DingService {
   Ding findById(Long id);
 
   void deleteById(Long id);
+
+  /**
+   * 向推送该client已经上线
+   * @param client 客户端
+   */
+  void pushOnlineMessage(Client client);
+
+  /**
+   * 向推送该client已经离线
+   * @param client 客户端
+   */
+  void pushOffLineMessage(Client client);
 }

--- a/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
+++ b/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
@@ -125,7 +125,8 @@ public class LogServiceImpl implements LogService {
         logIterator.remove();
       } else if (log.getMessage() == null || log.getMessage() == "") {
         // 更新最后交互日期，加上悲观锁，防止与离线任务冲突造成数据覆盖
-        transactionalService.setClientLastSendTimeWithPessimisticLock(log.getClient().getId());
+        Client client = transactionalService.setClientLastSendTimeWithPessimisticLock(log.getClient().getId());
+        logger.debug("更新最后交互时间为" + client.getLastSendTime());
 
         logIterator.remove();
         logger.debug("移除心跳包");

--- a/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
+++ b/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
@@ -1,14 +1,12 @@
 package club.yunzhi.log.service;
 
 import club.yunzhi.log.entity.Client;
-import club.yunzhi.log.entity.DayLog;
 import club.yunzhi.log.entity.Ding;
 import club.yunzhi.log.entity.Log;
 import club.yunzhi.log.enums.LogLevelEnum;
 import club.yunzhi.log.repository.ClientRepository;
 import club.yunzhi.log.repository.DingRepository;
 import club.yunzhi.log.repository.LogRepository;
-import com.mengyunzhi.core.service.CommonService;
 import com.mengyunzhi.core.service.YunzhiService;
 import com.mengyunzhi.core.service.YunzhiServiceImpl;
 import org.slf4j.Logger;
@@ -39,6 +37,9 @@ public class LogServiceImpl implements LogService {
   private DingService dingService;
   @Autowired
   private DingRepository dingRepository;
+  @Autowired
+  private TransactionalService transactionalService;
+
   private final ClientRepository clientRepository;
   private final static Logger logger = LoggerFactory.getLogger(LogServiceImpl.class);
 
@@ -115,7 +116,7 @@ public class LogServiceImpl implements LogService {
     clientService.update(logs);
   }
 
-  private void filter(List<Log> logs) throws ParseException {
+  void filter(List<Log> logs) throws ParseException {
     Iterator<Log> logIterator = logs.iterator();
     while (logIterator.hasNext()) {
       Log log = logIterator.next();
@@ -123,11 +124,9 @@ public class LogServiceImpl implements LogService {
         // 移除日志等级为trace或debug的
         logIterator.remove();
       } else if (log.getMessage() == null || log.getMessage() == "") {
-        //移除心跳包
-        Client client = clientRepository.findById(log.getClient().getId()).get();
-        client.setLastSendTime(new Timestamp(System.currentTimeMillis()));
-        clientRepository.save(client);
-        logger.debug("更新最后交互时间为" + client.getLastSendTime());
+        // 更新在线状态，离线已提醒字段，加上悲观锁，防止与心跳服务造成数据覆盖
+        transactionalService.setClientLastSendTimeWithPessimisticLock(log.getClient().getId());
+
         logIterator.remove();
         logger.debug("移除心跳包");
       } else if (log.getLevelCode().compareTo(LogLevelEnum.INFO.getValue()) == 0) {
@@ -148,15 +147,15 @@ public class LogServiceImpl implements LogService {
             Long currentTime = System.currentTimeMillis();
             int number = this.getNumOfErrorLogInTenMinutes(ding.getClient());
             logger.debug("发送error频率间隔为10分钟");
-            if (ding.getLastRemindErrorTime() == null || (currentTime - (Long)ding.getLastRemindErrorTime().getTime() > 600000)) {
+            if (ding.getLastRemindErrorTime() == null || (currentTime - (Long) ding.getLastRemindErrorTime().getTime() > 600000)) {
               logger.debug("提醒客户端出现了error");
               SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
               String dateString = formatter.format(new Date());
               String message = "执行推送任务" + "\n" + dateString + "\n"
                       + ("客户端: " + client.getName() + "  出现了ERROR") + "\n"
-                      + "内容：" + log.getMessage() + "\n" ;
-              if (number > 0){
-                message =  message.concat("该客户端10分钟内的error数: " + number);
+                      + "内容：" + log.getMessage() + "\n";
+              if (number > 0) {
+                message = message.concat("该客户端10分钟内的error数: " + number);
               }
               dingService.dingRequest(ding, message);
               // 设置当前推送error的时间

--- a/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
+++ b/api/src/main/java/club/yunzhi/log/service/LogServiceImpl.java
@@ -124,7 +124,7 @@ public class LogServiceImpl implements LogService {
         // 移除日志等级为trace或debug的
         logIterator.remove();
       } else if (log.getMessage() == null || log.getMessage() == "") {
-        // 更新在线状态，离线已提醒字段，加上悲观锁，防止与心跳服务造成数据覆盖
+        // 更新最后交互日期，加上悲观锁，防止与离线任务冲突造成数据覆盖
         transactionalService.setClientLastSendTimeWithPessimisticLock(log.getClient().getId());
 
         logIterator.remove();

--- a/api/src/main/java/club/yunzhi/log/service/TransactionalService.java
+++ b/api/src/main/java/club/yunzhi/log/service/TransactionalService.java
@@ -1,0 +1,27 @@
+package club.yunzhi.log.service;
+
+import club.yunzhi.log.entity.Client;
+
+/**
+ * 由于同类中调用事务注解的方法会造成事务注解失效
+ * 于是把事务方法提到一个该类中
+ * 由外部调用该事务方法
+ */
+public interface TransactionalService {
+  /**
+   * 设置客户端的lastSendTime
+   * 操作时加上悲观锁
+   * @param clientId 客户端id
+   * @return
+   */
+  Client setClientLastSendTimeWithPessimisticLock(Long clientId);
+
+  /**
+   * 设置客户端的已提醒字段和在线情况
+   * 操作时加上悲观锁
+   * @param clientId 客户端id
+   * @param state 在线状态
+   * @param remind 是否已提醒离线
+   */
+  Client setClientStateAndRemindWithPessimisticLock(Long clientId, Boolean state, Boolean remind);
+}

--- a/api/src/main/java/club/yunzhi/log/service/TransactionalServiceIml.java
+++ b/api/src/main/java/club/yunzhi/log/service/TransactionalServiceIml.java
@@ -1,0 +1,42 @@
+package club.yunzhi.log.service;
+
+import club.yunzhi.log.entity.Client;
+import club.yunzhi.log.repository.ClientRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+
+@Service
+public class TransactionalServiceIml implements TransactionalService {
+  @Autowired
+  private ClientRepository clientRepository;
+
+  private final Logger logger = LoggerFactory.getLogger(TransactionalServiceIml.class);
+
+  @Override
+  @Transactional(rollbackFor = Exception.class)
+  public Client setClientLastSendTimeWithPessimisticLock(Long clientId) {
+    // 查询时加上悲观锁
+    // 本事务结束前，其他线程不能修改，需要等待
+    Client client = clientRepository.findClientByIdWithPessimisticLock(clientId).get();
+    client.setLastSendTime(new Timestamp(System.currentTimeMillis()));
+    return clientRepository.save(client);
+  }
+
+  @Override
+  @Transactional(rollbackFor = Exception.class)
+  public Client setClientStateAndRemindWithPessimisticLock(Long clientId, Boolean state, Boolean remind) {
+    // 查询时加上悲观锁
+    // 本事务结束前，其他线程不能修改，需要等待
+    Client client = clientRepository.findClientByIdWithPessimisticLock(clientId).get();
+    client.setRemind(remind);
+    client.setState(state);
+    return clientRepository.save(client);
+  }
+
+
+}

--- a/api/src/main/java/club/yunzhi/log/service/TransactionalServiceImpl.java
+++ b/api/src/main/java/club/yunzhi/log/service/TransactionalServiceImpl.java
@@ -11,11 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.Timestamp;
 
 @Service
-public class TransactionalServiceIml implements TransactionalService {
+public class TransactionalServiceImpl implements TransactionalService {
   @Autowired
   private ClientRepository clientRepository;
 
-  private final Logger logger = LoggerFactory.getLogger(TransactionalServiceIml.class);
+  private final Logger logger = LoggerFactory.getLogger(TransactionalServiceImpl.class);
 
   @Override
   @Transactional(rollbackFor = Exception.class)

--- a/api/src/main/java/club/yunzhi/log/task/Init.java
+++ b/api/src/main/java/club/yunzhi/log/task/Init.java
@@ -47,7 +47,7 @@ public class Init implements ApplicationListener<ContextRefreshedEvent>, Ordered
     }
 
 
-    if (count == 0 ) {
+    if (count == 0) {
       Ding ding = new Ding();
       ding.setSecret(secret);
       ding.setWebHook(webHook);
@@ -78,7 +78,7 @@ public class Init implements ApplicationListener<ContextRefreshedEvent>, Ordered
       } else {
         Long timestamp = client.getLastSendTime().getTime();
         Long currentTime = System.currentTimeMillis();
-        if(currentTime - timestamp > 300000 && client.getState()) {
+        if (currentTime - timestamp > 300000 && client.getState()) {
           logger.debug("上一次响应时间超过5分钟并且为在线状态，更改状态为离线");
           client.setState(false);
         }

--- a/api/src/main/java/club/yunzhi/log/task/OfflineClientTaskImpl.java
+++ b/api/src/main/java/club/yunzhi/log/task/OfflineClientTaskImpl.java
@@ -45,6 +45,7 @@ public class OfflineClientTaskImpl implements OfflineClientTask {
         Long currentTime = System.currentTimeMillis();
         if (currentTime - timestamp > 300000 && client.getState()) {
           logger.debug("上一次响应时间超过5分钟并且为在线状态，更改状态为离线");
+          logger.debug("上次时间" + timestamp + "现在时间" + currentTime);
           Boolean state = false;
           Boolean remind = false;
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -57,7 +57,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
   datasource:
     #    数据库名称关系到数据库迁移
-    url: jdbc:mysql://${datasource.url:127.0.0.1}:${datasource.port:3306}/${datasource.dbname:log}?useUnicode=true&characterEncoding=utf-8&useSSL=false
+    url: jdbc:mysql://${datasource.url:127.0.0.1}:${datasource.port:3306}/${datasource.dbname:log}?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai
     username: ${datasource.username:root}
     password: ${datasource.password:}
     separator: //
@@ -90,7 +90,7 @@ spring:
 
   datasource:
     #    数据库名称关系到数据库迁移
-    url: jdbc:mysql://${datasource.url:ci.mengyunzhi.com}:${datasource.port:3609}/${datasource.dbname:log}?useUnicode=true&characterEncoding=utf-8&useSSL=false
+    url: jdbc:mysql://${datasource.url:ci.mengyunzhi.com}:${datasource.port:3609}/${datasource.dbname:log}?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai
     username: ${datasource.username:root}
     password: ${datasource.password:yunzhi.club}
     separator: //


### PR DESCRIPTION
#310 
由于“写”的场景比较多，于是添加了悲观锁，事务结束前，其他线程不能修改，需要等待。

由于同类中调用事务注解的方法会造成事务注解失效，于是把新建了事务方法serive，由外部调用该事务方法

排除到一个因为后台连接数据库时候，因为没有制定时区，导致保存时间出错
 